### PR TITLE
Generation fixed

### DIFF
--- a/Sources/table/FileType.swift
+++ b/Sources/table/FileType.swift
@@ -3,6 +3,7 @@ enum FileType: CaseIterable {
   case table // own table format
   case sql
   case cassandraSql
+  case generated
 
   static func hasOuterBorders(type: FileType) -> Bool {
     switch type {

--- a/Sources/table/Table.swift
+++ b/Sources/table/Table.swift
@@ -73,12 +73,12 @@ class ParsedTable: Table {
         return try! row.map { row in 
             let components = try ParsedTable.readRowComponents(row, type: conf.type, delimeter: conf.delimeter, trim: conf.trim)
 
-            if (components.count != conf.header.size) {
-                debug("WARN: Row \(line) has \(components.count) components, but header has \(conf.header.size) columns. Row:\n'\(row)'")
+            if (components.count != header.size) {
+                debug("WARN: Row \(line) has \(components.count) components, but header has \(header.size) columns. Row:\n'\(row)'")
             }
 
             return Row(
-                header: conf.header,
+                header: header,
                 index:line, 
                 components: components
             ) 
@@ -90,7 +90,7 @@ class ParsedTable: Table {
     }
 
     static func generated(rows: Int) -> ParsedTable {        
-        return ParsedTable(reader: GeneratedLineReader(lines: rows), conf: TableConfig(header: Header.auto(size: 0)), prereadRows: [])
+        return ParsedTable(reader: GeneratedLineReader(lines: rows), conf: TableConfig(header: Header.auto(size: 0), type: .generated), prereadRows: [])
     }
 
     static func fromArray(_ data: [[String]], header: [String]? = nil) -> ParsedTable {
@@ -227,6 +227,10 @@ class ParsedTable: Table {
 
     // extended version that can skip multiple technical rows based on file type, used inside of the file parsing loop
     private static func technicalPart(type: FileType, str: String?) -> Int {
+        if (type == .generated) {
+            return 0;
+        }
+
         if (type == .cassandraSql && "---MORE---" == str) {
             // more + header + a line
             return 3;

--- a/Tests/table-Tests/NewColumnsTableViewTests.swift
+++ b/Tests/table-Tests/NewColumnsTableViewTests.swift
@@ -140,6 +140,34 @@ class NewColumnsTableViewTests: XCTestCase {
         XCTAssertNil(try newColumnsTable.next())
     }
     
+    func testGeneratedTableWithNewColumns() throws {
+        let table = ParsedTable.generated(rows: 2)
+        
+        let statusFormat = try Format(format: "generated").validated(header: nil)
+        let sourceFormat = try Format(format: "cli").validated(header: nil)
+        let newColumnsTable = NewColumnsTableView(
+            table: table,
+            additionalColumns: [
+                ("status", statusFormat),
+                ("source", sourceFormat)
+            ]
+        )
+        
+        XCTAssertEqual(newColumnsTable.header.columnsStr(), "status,source")
+        
+        let row1 = try newColumnsTable.next()!
+        XCTAssertEqual(row1.index, 0)
+        XCTAssertEqual(row1["status"], "generated")
+        XCTAssertEqual(row1["source"], "cli")
+        
+        let row2 = try newColumnsTable.next()!
+        XCTAssertEqual(row2.index, 1)
+        XCTAssertEqual(row2["status"], "generated")
+        XCTAssertEqual(row2["source"], "cli")
+        
+        XCTAssertNil(try newColumnsTable.next())
+    }
+    
     func testPreservesRowIndex() throws {
         let table = ParsedTable.fromArray([
             ["Alice"],


### PR DESCRIPTION
Fix for generation logic, which was producing empty output caused by empty rows skipping